### PR TITLE
fix: Remove credentials from user manual

### DIFF
--- a/docs/07. Manuales de usuario/7.3. Software Reviewer Guideline - Sprint 3.mdx
+++ b/docs/07. Manuales de usuario/7.3. Software Reviewer Guideline - Sprint 3.mdx
@@ -74,7 +74,7 @@ Para usar la aplicación es necesario iniciar sesión, por tanto esta página se
 
 <img src="/img/usermanual/sprint3/acat-home.png" height="50%"/>
 
-Para iniciar sesión puede rellenar el siguiente formulario con sus credenciales (usuario: aruiz_acat, contraseña: aruiz123.), y avanzar a la siguiente vista.
+Si no tiene credenciales de acceso y las necesita para revisar o probar el software, por favor contacte con nosotros.
 
 ## Listado de Beneficiarios
 
@@ -199,7 +199,7 @@ Para usar la aplicación es necesario iniciar sesión, por tanto esta página se
 
 <img src="/img/usermanual/sprint3/cyc-home.png" height="50%"/>
 
-Para iniciar sesión puede rellenar el siguiente formulario con sus credenciales (usuario: aruiz_cyc, contraseña: aruiz123.), y avanzar a la siguiente vista.
+Si no tiene credenciales de acceso y las necesita para revisar o probar el software, por favor contacte con nosotros.
 
 ## Listado de Familias
 


### PR DESCRIPTION
# Description
Remove user credentials from user manual

# Checklist:
- [X] I have performed a self-review of my code running `npm run build` and `npm run serve` after pushing the code.
- [X] I have checked that there is no fragile information published unintentionally.